### PR TITLE
Default to HEAD when asking the user for a rev

### DIFF
--- a/gitlab-pipeline.el
+++ b/gitlab-pipeline.el
@@ -117,7 +117,7 @@
            (repo (nth 2 parts)))
       (let ((sha))
         (if (fboundp 'magit-commit-at-point) (setq sha (magit-commit-at-point)))
-        (unless sha (setq sha (read-string "Rev: ")))
+        (unless sha (setq sha (read-string "Rev: " nil nil "HEAD")))
         (setq sha (replace-regexp-in-string "\n" "" (shell-command-to-string (format "git rev-parse %s" sha))))
         (gitlab-pipeline-show-pipeline-from-sha (format "%s/api/v4" host) (url-hexify-string repo) sha))
     (user-error "Cannot parse origin: %s" origin-url)))

--- a/gitlab-pipeline.el
+++ b/gitlab-pipeline.el
@@ -117,7 +117,7 @@
            (repo (nth 2 parts)))
       (let ((sha))
         (if (fboundp 'magit-commit-at-point) (setq sha (magit-commit-at-point)))
-        (unless sha (setq sha (read-string "Rev: " nil nil "HEAD")))
+        (unless sha (setq sha (read-string "Rev(HEAD): " nil nil "HEAD")))
         (setq sha (replace-regexp-in-string "\n" "" (shell-command-to-string (format "git rev-parse %s" sha))))
         (gitlab-pipeline-show-pipeline-from-sha (format "%s/api/v4" host) (url-hexify-string repo) sha))
     (user-error "Cannot parse origin: %s" origin-url)))


### PR DESCRIPTION
The idea behind this change is to be able to easily get the status of the pipeline from any buffer corresponding to the commit that's currently checked out without having to find a buffer where to fish magit-commit-at-point from.

Thanks for considering it!