### PR TITLE
Allow customising Ghub's token name

### DIFF
--- a/README.org
+++ b/README.org
@@ -14,6 +14,10 @@ More detail https://magit.vc/manual/ghub
 machine <your-gitlab-host>/api/v4 login <your-gitlab-user>^ghub password ****
 #+END_SRC
 
+You can also use your own Ghub authentication token (or even reuse an
+existing one like Forge's) by customising
+`gitlab-pipeline-ghub-auth-token`.
+
 ** Usage
 
 - Get pipelines of SHA git-commit


### PR DESCRIPTION
For instance if you use Forge with Gitlab directly you might have set up only a ^forge token in auth-source. This token definition could be also valid for gitlab-pipeline.

This patch allows reusing this token by allowing to customise how the auth is configured when calling ghub-{get, post}, etc.